### PR TITLE
Add "dump_game_options" option for dumping hidden INI settings

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -51,6 +51,7 @@ Options::Options(HMODULE aModule)
         this->PatchSkipStartMenu = config.value("skip_start_menu", this->PatchSkipStartMenu);
         this->PatchAsyncCompute = config.value("disable_async_compute", this->PatchAsyncCompute);
         this->PatchAntialiasing = config.value("disable_antialiasing", this->PatchAntialiasing);
+        this->DumpGameOptions = config.value("dump_game_options", this->DumpGameOptions);
     }
 
     nlohmann::json config;
@@ -66,6 +67,7 @@ Options::Options(HMODULE aModule)
     config["skip_start_menu"] = this->PatchSkipStartMenu;
     config["disable_async_compute"] = this->PatchAsyncCompute;
     config["disable_antialiasing"] = this->PatchAntialiasing;
+    config["dump_game_options"] = this->DumpGameOptions;
 
     std::ofstream o(configPath);
     o << config.dump(4) << std::endl;

--- a/src/Options.h
+++ b/src/Options.h
@@ -21,6 +21,7 @@ struct Options
 	bool PatchAsyncCompute{ false };
 	bool PatchAntialiasing{ false };
 	bool PatchSkipStartMenu{ true };
+	bool DumpGameOptions{ false };
 	float CPUMemoryPoolFraction{ 0.5f };
 	float GPUMemoryPoolFraction{ 1.f };
 	std::filesystem::path Path;

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -22,6 +22,7 @@ void SpinLockPatch(Image* apImage);
 void StartScreenPatch(Image* apImage);
 void RemovePedsPatch(Image* apImage);
 void OptionsPatch(Image* apImage);
+void OptionsInitPatch(Image* apImage);
 
 void Initialize(HMODULE mod)
 {
@@ -64,6 +65,9 @@ void Initialize(HMODULE mod)
 
     if(options.PatchAsyncCompute || options.PatchAntialiasing)
         OptionsPatch(&image);
+
+    if (options.DumpGameOptions)
+        OptionsInitPatch(&image);
 
     spdlog::default_logger()->flush();
 }

--- a/src/options_patch.cpp
+++ b/src/options_patch.cpp
@@ -37,6 +37,10 @@ bool HookGamePropertyGetBoolean(GameProperty* apThis, uint8_t* apVariable, uint8
     {
         *pVariable = false;
     }
+    else if (Options::Get().PatchAntialiasing && strcmp(apThis->pName, "ScreenSpaceReflection") == 0)
+    {
+        *pVariable = false;
+    }
 
     if (aKind != apThis->kind)
         return false;

--- a/src/options_patch.cpp
+++ b/src/options_patch.cpp
@@ -1,7 +1,44 @@
 #include "Image.h"
 #include <spdlog/spdlog.h>
+#include <MinHook.h>
+#include <sstream>
 #include "Options.h"
 #include "Pattern.h"
+
+struct GamePropertyString
+{
+    union
+    {
+        char* pValue;
+        char pbValue[0x10];
+    };
+
+    uint32_t unk10; // some reason we can't add this to the union above
+
+    uint32_t length_flags;
+
+    // TODO: locate the actual string get/set functions in the game and use those instead
+    char* get()
+    {
+        // Game will try storing the value inside this struct if the length is smaller than 0x14/0x10
+        // Otherwise value is relocated to some other addr, and length gets 0x40000000 added to it to signal that
+
+        if (length_flags >= 0x40000000)
+            return pValue;
+
+        return pbValue;
+    }
+};
+static_assert(offsetof(GamePropertyString, length_flags) == 0x14);
+
+enum class GamePropertyType : uint8_t
+{
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Color // stored as int32
+};
 
 struct GameProperty
 {
@@ -11,19 +48,61 @@ struct GameProperty
     const char* pCategory;
     uint64_t unk18;
     uint64_t unk20;
-    uint8_t kind;
-    uint8_t type; // 2 is boolean
+    GamePropertyType type;
+    uint8_t flag;
     uint8_t pad2A[0x30 - 0x2A];
     union
     {
         bool* pBoolean;
+        uint32_t* pInteger;
+        float* pFloat;
+        GamePropertyString* pString;
     };
+
+    std::string getInfo()
+    {
+        std::stringstream ret;
+
+        if (pCategory)
+            ret << pCategory << "/";
+
+        if(pName)
+            ret << pName;
+
+        ret << " = ";
+
+        switch (type)
+        {
+        case GamePropertyType::Boolean:
+            if(pBoolean)
+                ret << (*pBoolean ? "true" : "false");
+            break;
+        case GamePropertyType::Integer:
+            if(pInteger)
+                ret << *pInteger;
+            break;
+        case GamePropertyType::Float:
+            if (pFloat)
+                ret << *pFloat;
+            break;
+        case GamePropertyType::String:
+            if (pString)
+                ret << pString->get();
+            break;
+        case GamePropertyType::Color:
+            if (pInteger)
+                ret << "0x" << std::hex << *pInteger << std::dec;
+            break;
+        }
+
+        return ret.str();
+    }
 };
 
-static_assert(offsetof(GameProperty, kind) == 0x28);
+static_assert(offsetof(GameProperty, type) == 0x28);
 static_assert(offsetof(GameProperty, pBoolean) == 0x30);
 
-bool HookGamePropertyGetBoolean(GameProperty* apThis, uint8_t* apVariable, uint8_t aKind)
+bool HookGamePropertyGetBoolean(GameProperty* apThis, uint8_t* apVariable, GamePropertyType aType)
 {
     auto* pVariable = apThis->pBoolean;
     if (!pVariable)
@@ -42,7 +121,7 @@ bool HookGamePropertyGetBoolean(GameProperty* apThis, uint8_t* apVariable, uint8
         *pVariable = false;
     }
 
-    if (aKind != apThis->kind)
+    if (aType != apThis->type)
         return false;
 
     *apVariable = *pVariable;
@@ -76,4 +155,45 @@ void OptionsPatch(Image* apImage)
     }
     else
         spdlog::info("\tHidden options patch: failed");
+}
+
+using TGamePropertyInit = void*(void*);
+TGamePropertyInit* RealGamePropertyInit = nullptr;
+
+// GameProperty pointers should remain valid for lifetime of the game
+std::vector<GameProperty*> GameProperties;
+
+void* HookGamePropertyInit(GameProperty* apThis)
+{
+    if (std::find(GameProperties.begin(), GameProperties.end(), apThis) == GameProperties.end())
+    {
+        GameProperties.push_back(apThis);
+    }
+    else
+    {
+        // GamePropertyInit seems to be called twice per property, value isn't set until after the first call though
+        // Since we've already seen this property once we can now grab the value
+
+        spdlog::info(apThis->getInfo());
+    }
+
+    return RealGamePropertyInit(apThis);
+}
+
+void OptionsInitPatch(Image* apImage)
+{
+    void* GamePropertyInit = FindSignature(apImage->pTextStart, apImage->pTextEnd,
+        { 0x48, 0x89, 0x5C, 0x24, 0x08, 0x48, 0x89, 0x74, 0x24, 0x10, 0x57,
+          0x48, 0x83, 0xEC, 0x40, 0x48, 0x8B, 0xF1, 0x48, 0x8D, 0x4C, 0x24, 0x20,
+          0xE8 });
+
+    if (GamePropertyInit)
+    {
+        MH_CreateHook(GamePropertyInit, &HookGamePropertyInit, reinterpret_cast<void**>(&RealGamePropertyInit));
+        MH_EnableHook(GamePropertyInit);
+
+        spdlog::info("\tHidden options hook: success");
+    }
+    else
+        spdlog::info("\tHidden options hook: failed");
 }


### PR DESCRIPTION
Even though all the INI settings have already been dumped by others, it could come in useful to have this feature for any future game updates.
The code for it also lets us track all the GameProperty pointers too, in case we ever need to read/write from any of them.

(Also made it so SSR will be disabled automatically if AA is disabled, like mentioned in #101)

E: btw to test this I had to add MH_Initialize() inside dllmain's Initialize, I'm guessing the MinHook changes are maybe WIP though so didn't include that change here.