### PR TITLE
Initial impl. of disable_intro_movies

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -53,6 +53,7 @@ Options::Options(HMODULE aModule)
         this->PatchAntialiasing = config.value("disable_antialiasing", this->PatchAntialiasing);
         this->DumpGameOptions = config.value("dump_game_options", this->DumpGameOptions);
         this->Console = config.value("console", this->Console);
+        this->DisableIntroMovies = config.value("disable_intro_movies", this->DisableIntroMovies);
     }
 
     nlohmann::json config;
@@ -70,6 +71,7 @@ Options::Options(HMODULE aModule)
     config["disable_antialiasing"] = this->PatchAntialiasing;
     config["dump_game_options"] = this->DumpGameOptions;
     config["console"] = this->Console;
+    config["disable_intro_movies"] = this->DisableIntroMovies;
 
     std::ofstream o(configPath);
     o << config.dump(4) << std::endl;

--- a/src/Options.h
+++ b/src/Options.h
@@ -23,6 +23,7 @@ struct Options
 	bool PatchSkipStartMenu{ true };
 	bool DumpGameOptions{ false };
 	bool Console{ true };
+	bool DisableIntroMovies{ false };
 	float CPUMemoryPoolFraction{ 0.5f };
 	float GPUMemoryPoolFraction{ 1.f };
 	std::filesystem::path Path;

--- a/src/disable_intro_movies.cpp
+++ b/src/disable_intro_movies.cpp
@@ -1,0 +1,48 @@
+#include <windows.h>
+#include <MinHook.h>
+#include "Image.h"
+#include <spdlog/spdlog.h>
+#include "REDString.h"
+#include "Pattern.h"
+
+using TInitScriptMemberVariable = void*(void* a1, void* a2, uint64_t a3, uint64_t nameHash, void* a5, void* a6, void* a7);
+TInitScriptMemberVariable* RealInitScriptMemberVariable = nullptr;
+
+void* HookInitScriptMemberVariable(void* a1, void* a2, uint64_t a3, uint64_t nameHash, void* a5, void* a6, void* a7)
+{
+    // Break the nameHash of some SplashScreenLoadingScreenLogicController variables
+    // Should prevent the intro screen scripts from finding the intro bink, which makes it show a loading screen instead
+    // (intro movie audio still plays though - this can be stopped by disabling more script vars, but unfortunately that'll also make it load infinitely)
+    // For me the loading screen takes almost as much time as the intro movie itself did, but the audio shows that a few seconds are saved with this, maybe faster machines can save even more time.
+
+    // Ideally I think the real solution is to change GameFramework/InitialState INI variable from "Initialization" to "PreGameSession" or "MainMenu" instead
+    // Unfortunately that causes a black screen on launch though, likely only works properly on non-shipping builds
+
+    if (nameHash == REDString::Hash("logoTrainWBBink") ||
+        nameHash == REDString::Hash("logoTrainNamcoBink") ||
+        nameHash == REDString::Hash("logoTrainStadiaBink") ||
+        nameHash == REDString::Hash("logoTrainNoRTXBink") ||
+        nameHash == REDString::Hash("logoTrainRTXBink") ||
+        nameHash == REDString::Hash("introMessageBink"))
+    {
+        nameHash = ~nameHash;
+    }
+
+    return RealInitScriptMemberVariable(a1, a2, a3, nameHash, a5, a6, a7);
+}
+
+void DisableIntroMoviesPatch(Image* apImage)
+{
+    RealInitScriptMemberVariable = reinterpret_cast<TInitScriptMemberVariable*>(FindSignature(apImage->pTextStart, apImage->pTextEnd, {
+        0x48, 0x89, 0x5C, 0x24, 0x08, 0x57, 0x48, 0x83, 0xEC, 0x20, 0x48, 0x8B, 0x44, 0x24, 0x50, 0x48, 0x8B, 0xD9, 0x48, 0x89, 0x41, 0x08
+        }));
+
+    if (RealInitScriptMemberVariable == nullptr)
+    {
+        spdlog::info("\tDisable intro movies patch: failed, could not be found");
+        return;
+    }
+
+    MH_CreateHook(RealInitScriptMemberVariable, &HookInitScriptMemberVariable, reinterpret_cast<void**>(&RealInitScriptMemberVariable));
+    spdlog::info("\tDisable intro movies patch: success");
+}

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -26,6 +26,7 @@ void StartScreenPatch(Image* apImage);
 void RemovePedsPatch(Image* apImage);
 void OptionsPatch(Image* apImage);
 void OptionsInitPatch(Image* apImage);
+void DisableIntroMoviesPatch(Image* apImage);
 
 void Initialize(HMODULE mod)
 {
@@ -71,6 +72,9 @@ void Initialize(HMODULE mod)
 
     if(options.Console)
         Overlay::Initialize(&image);
+
+    if (options.DisableIntroMovies)
+        DisableIntroMoviesPatch(&image);
 
     MH_EnableHook(MH_ALL_HOOKS);
 


### PR DESCRIPTION
Added a way to disable intro movies mostly as described at https://github.com/yamashi/PerformanceOverhaulCyberpunk/issues/75#issuecomment-747723572, except I changed it to break the name hashes of those variables via a hook instead of needing to patch in jump calls around them, should make it easier to port across versions I think.

Still a pretty hacky workaround though, hopefully a better solution will be found eventually, but I've spent many hours trying different things and this variable breaking method was the best result I've had so far.

Like mentioned on that comment the audio for intro will still play, but the game should let you get to the "press space to continue" screen a little bit quicker than with the intro video, maybe goes even faster with better machines too. (this also causes a small glitch where intro audio & the demo/attract video plays at the same time, it's only minor though so oh well, probably gonna try looking into skipping that demo screen soon too so hopefully can get rid of that)

If this does get merged it'd probably be a good idea to mention about the audio still playing, before anyone complains about it...