### PR TITLE
Made the console key configurable

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -57,6 +57,7 @@ Options::Options(HMODULE aModule)
 
         this->DumpGameOptions = config.value("dump_game_options", this->DumpGameOptions);
         this->Console = config.value("console", this->Console);
+		this->ConsoleKey = config.value("console_key", this->ConsoleKey);
 
         // check old config names
         if (config.value("unlock_menu", false))
@@ -78,6 +79,7 @@ Options::Options(HMODULE aModule)
     config["disable_antialiasing"] = this->PatchAntialiasing;
     config["dump_game_options"] = this->DumpGameOptions;
     config["console"] = this->Console;
+    config["console_key"] = this->ConsoleKey;
     config["disable_intro_movies"] = this->PatchDisableIntroMovies;
     config["disable_vignette"] = this->PatchDisableVignette;
     config["disable_boundary_teleport"] = this->PatchDisableBoundaryTeleport;

--- a/src/Options.h
+++ b/src/Options.h
@@ -27,6 +27,7 @@ struct Options
 
 	bool DumpGameOptions{ false };
 	bool Console{ true };
+	int ConsoleKey{ VK_OEM_3 };
 	float CPUMemoryPoolFraction{ 0.5f };
 	float GPUMemoryPoolFraction{ 1.f };
 	std::filesystem::path Path;

--- a/src/overlay/Overlay.cpp
+++ b/src/overlay/Overlay.cpp
@@ -15,7 +15,6 @@
 #include "imgui_impl_dx12.h"
 #include "imgui_impl_win32.h"
 
-
 static std::shared_ptr<Overlay> s_pOverlay;
 
 void Overlay::Initialize(Image* apImage)
@@ -83,12 +82,9 @@ LRESULT APIENTRY WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     switch (uMsg)
     {
     case WM_KEYDOWN:
-        switch (wParam)
-        {
-        case VK_END:
+        if (wParam == Options::Get().ConsoleKey)
             s_pOverlay->Toggle();
-            break;
-        }
+		break;
     default:
         break;
     }


### PR DESCRIPTION
The end-user will need to refer to the [virtual key codes](https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes) if they wish to change it. This should resolve #133.